### PR TITLE
feat: per-repo Redis stream routing in watch config

### DIFF
--- a/internal/handlers/pitch.go
+++ b/internal/handlers/pitch.go
@@ -49,7 +49,7 @@ func NewPitchHandler(p pitcher.Pitcher) http.HandlerFunc {
 			msg.System = "homerun2-git-pitcher"
 		}
 
-		objectID, streamID, err := p.Pitch(msg)
+		objectID, streamID, err := p.Pitch(msg, "")
 		if err != nil {
 			slog.Error("failed to pitch message", "error", err)
 			respondWithError(w, http.StatusServiceUnavailable, "Failed to enqueue message")

--- a/internal/pitcher/pitcher.go
+++ b/internal/pitcher/pitcher.go
@@ -15,8 +15,10 @@ import (
 )
 
 // Pitcher defines the interface for message delivery backends.
+// streamOverride, if non-empty, directs the message to a specific Redis stream
+// instead of the backend's default. File/other backends may ignore it.
 type Pitcher interface {
-	Pitch(msg homerun.Message) (objectID, streamID string, err error)
+	Pitch(msg homerun.Message, streamOverride string) (objectID, streamID string, err error)
 }
 
 // RedisPitcher enqueues messages into Redis Streams.
@@ -38,8 +40,14 @@ func (p *RedisPitcher) HealthCheck(ctx context.Context) error {
 	return nil
 }
 
-func (p *RedisPitcher) Pitch(msg homerun.Message) (string, string, error) {
-	objectID, streamID, err := homerun.EnqueueMessageInRedisStreams(msg, p.Config)
+func (p *RedisPitcher) Pitch(msg homerun.Message, streamOverride string) (string, string, error) {
+	var objectID, streamID string
+	var err error
+	if streamOverride != "" {
+		objectID, streamID, err = homerun.EnqueueMessageInRedisStreams(msg, p.Config, streamOverride)
+	} else {
+		objectID, streamID, err = homerun.EnqueueMessageInRedisStreams(msg, p.Config)
+	}
 	if err != nil {
 		return "", "", fmt.Errorf("failed to enqueue message to Redis stream: %w", err)
 	}
@@ -52,7 +60,8 @@ type FilePitcher struct {
 	mu   sync.Mutex
 }
 
-func (p *FilePitcher) Pitch(msg homerun.Message) (string, string, error) {
+func (p *FilePitcher) Pitch(msg homerun.Message, streamOverride string) (string, string, error) {
+	_ = streamOverride
 	p.mu.Lock()
 	defer p.mu.Unlock()
 

--- a/internal/watcher/bridge.go
+++ b/internal/watcher/bridge.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 
 	"github.com/stuttgart-things/homerun2-git-pitcher/internal/pitcher"
-	homerun "github.com/stuttgart-things/homerun-library/v3"
 )
 
 // Bridge connects a GitWatcher to a Pitcher, reading events from the
@@ -19,13 +18,13 @@ type Bridge struct {
 // Run starts the watcher and pitches all received events until ctx is cancelled.
 // It flushes the dedup store on shutdown.
 func (b *Bridge) Run(ctx context.Context) error {
-	msgs, err := b.Watcher.Watch(ctx)
+	events, err := b.Watcher.Watch(ctx)
 	if err != nil {
 		return err
 	}
 
-	for msg := range msgs {
-		b.pitch(msg)
+	for ev := range events {
+		b.pitch(ev)
 	}
 
 	// Flush dedup state on shutdown.
@@ -39,9 +38,10 @@ func (b *Bridge) Run(ctx context.Context) error {
 	return nil
 }
 
-// pitch sends a single message to the pitcher backend and logs the result.
-func (b *Bridge) pitch(msg homerun.Message) {
-	objectID, streamID, err := b.Pitcher.Pitch(msg)
+// pitch sends a single event to the pitcher backend and logs the result.
+func (b *Bridge) pitch(ev PitchEvent) {
+	msg := ev.Message
+	objectID, streamID, err := b.Pitcher.Pitch(msg, ev.Stream)
 	if err != nil {
 		slog.Error("failed to pitch event",
 			"title", msg.Title,
@@ -56,6 +56,7 @@ func (b *Bridge) pitch(msg homerun.Message) {
 		"author", msg.Author,
 		"objectID", objectID,
 		"streamID", streamID,
+		"streamOverride", ev.Stream,
 		"tags", msg.Tags,
 		"url", msg.Url,
 	)

--- a/internal/watcher/bridge_test.go
+++ b/internal/watcher/bridge_test.go
@@ -8,42 +8,44 @@ import (
 	homerun "github.com/stuttgart-things/homerun-library/v3"
 )
 
-// mockPitcher records all pitched messages.
+// mockPitcher records all pitched messages and their stream overrides.
 type mockPitcher struct {
 	mu       sync.Mutex
 	messages []homerun.Message
+	streams  []string
 }
 
-func (m *mockPitcher) Pitch(msg homerun.Message) (string, string, error) {
+func (m *mockPitcher) Pitch(msg homerun.Message, streamOverride string) (string, string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.messages = append(m.messages, msg)
+	m.streams = append(m.streams, streamOverride)
 	return "obj-1", "stream-1", nil
 }
 
-// mockWatcher sends predefined messages then closes the channel.
+// mockWatcher sends predefined events then closes the channel.
 type mockWatcher struct {
-	msgs []homerun.Message
+	events []PitchEvent
 }
 
-func (m *mockWatcher) Watch(_ context.Context) (<-chan homerun.Message, error) {
-	ch := make(chan homerun.Message, len(m.msgs))
-	for _, msg := range m.msgs {
-		ch <- msg
+func (m *mockWatcher) Watch(_ context.Context) (<-chan PitchEvent, error) {
+	ch := make(chan PitchEvent, len(m.events))
+	for _, ev := range m.events {
+		ch <- ev
 	}
 	close(ch)
 	return ch, nil
 }
 
 func TestBridge_Run(t *testing.T) {
-	testMsgs := []homerun.Message{
-		{Title: "Push to main on org/repo", Severity: "info", System: "homerun2-git-pitcher"},
-		{Title: "PR #42: Add feature (opened)", Severity: "info", System: "homerun2-git-pitcher"},
-		{Title: "Release v1.0.0 on org/repo", Severity: "success", System: "homerun2-git-pitcher"},
+	testEvents := []PitchEvent{
+		{Message: homerun.Message{Title: "Push to main on org/repo", Severity: "info", System: "homerun2-git-pitcher"}},
+		{Message: homerun.Message{Title: "PR #42: Add feature (opened)", Severity: "info", System: "homerun2-git-pitcher"}},
+		{Message: homerun.Message{Title: "Release v1.0.0 on org/repo", Severity: "success", System: "homerun2-git-pitcher"}, Stream: "releases"},
 	}
 
 	p := &mockPitcher{}
-	w := &mockWatcher{msgs: testMsgs}
+	w := &mockWatcher{events: testEvents}
 	dedup, _ := NewMemoryDedupStore(DefaultDedupConfig(), "")
 
 	bridge := &Bridge{
@@ -67,5 +69,11 @@ func TestBridge_Run(t *testing.T) {
 	}
 	if p.messages[2].Severity != "success" {
 		t.Errorf("expected severity 'success' for release, got %q", p.messages[2].Severity)
+	}
+	if p.streams[0] != "" {
+		t.Errorf("expected empty stream override for push, got %q", p.streams[0])
+	}
+	if p.streams[2] != "releases" {
+		t.Errorf("expected stream override 'releases' for release, got %q", p.streams[2])
 	}
 }

--- a/internal/watcher/config.go
+++ b/internal/watcher/config.go
@@ -10,6 +10,9 @@ import (
 
 // WatchConfig is the top-level configuration for the git-pitcher watcher.
 type WatchConfig struct {
+	// Stream is the default Redis stream name for all published events.
+	// If empty, the pitcher falls back to REDIS_STREAM / its hardcoded default.
+	Stream string       `yaml:"stream"`
 	GitHub GitHubConfig `yaml:"github"`
 }
 
@@ -26,6 +29,17 @@ type RepoConfig struct {
 	Name     string        `yaml:"name"`
 	Interval time.Duration `yaml:"interval"`
 	Events   []EventKind   `yaml:"events"`
+	// Stream overrides the top-level WatchConfig.Stream for this repo.
+	Stream string `yaml:"stream"`
+}
+
+// ResolveStream returns the stream for events from this repo.
+// Precedence: repo-level override → top-level default → "" (caller falls back).
+func (c *WatchConfig) ResolveStream(repo RepoConfig) string {
+	if repo.Stream != "" {
+		return repo.Stream
+	}
+	return c.Stream
 }
 
 // EventKind represents a type of GitHub event to watch.

--- a/internal/watcher/config_test.go
+++ b/internal/watcher/config_test.go
@@ -133,3 +133,27 @@ func TestLoadWatchConfigValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveStream(t *testing.T) {
+	cfg := &WatchConfig{Stream: "default-stream"}
+	cases := []struct {
+		name    string
+		cfgTop  string
+		repo    RepoConfig
+		want    string
+	}{
+		{"repo override wins", "default-stream", RepoConfig{Owner: "o", Name: "r", Stream: "releases"}, "releases"},
+		{"top-level fallback", "default-stream", RepoConfig{Owner: "o", Name: "r"}, "default-stream"},
+		{"neither set returns empty", "", RepoConfig{Owner: "o", Name: "r"}, ""},
+		{"empty repo override falls through", "top", RepoConfig{Owner: "o", Name: "r", Stream: ""}, "top"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg.Stream = tc.cfgTop
+			got := cfg.ResolveStream(tc.repo)
+			if got != tc.want {
+				t.Errorf("ResolveStream: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/watcher/github.go
+++ b/internal/watcher/github.go
@@ -55,8 +55,8 @@ func NewGitHubWatcher(cfg *WatchConfig, dedup DedupStore) *GitHubWatcher {
 // Watch starts a goroutine per configured repo that polls for events at the
 // configured interval. Events are converted to homerun Messages and sent on
 // the returned channel. Polling stops when ctx is cancelled.
-func (w *GitHubWatcher) Watch(ctx context.Context) (<-chan homerun.Message, error) {
-	msgs := make(chan homerun.Message, 100)
+func (w *GitHubWatcher) Watch(ctx context.Context) (<-chan PitchEvent, error) {
+	msgs := make(chan PitchEvent, 100)
 
 	var wg sync.WaitGroup
 	for _, repo := range w.config.GitHub.Repos {
@@ -76,7 +76,7 @@ func (w *GitHubWatcher) Watch(ctx context.Context) (<-chan homerun.Message, erro
 }
 
 // pollRepo polls a single repo at its configured interval.
-func (w *GitHubWatcher) pollRepo(ctx context.Context, repo RepoConfig, msgs chan<- homerun.Message) {
+func (w *GitHubWatcher) pollRepo(ctx context.Context, repo RepoConfig, msgs chan<- PitchEvent) {
 	logger := slog.With("repo", repo.FullName())
 	logger.Info("starting watcher", "interval", repo.Interval, "events", repo.Events)
 
@@ -102,7 +102,7 @@ func (w *GitHubWatcher) pollRepo(ctx context.Context, repo RepoConfig, msgs chan
 }
 
 // fetchAndSend fetches recent events from GitHub and sends new ones as messages.
-func (w *GitHubWatcher) fetchAndSend(ctx context.Context, repo RepoConfig, msgs chan<- homerun.Message) {
+func (w *GitHubWatcher) fetchAndSend(ctx context.Context, repo RepoConfig, msgs chan<- PitchEvent) {
 	logger := slog.With("repo", repo.FullName())
 
 	events, resp, err := w.client.Activity.ListRepositoryEvents(ctx, repo.Owner, repo.Name, &github.ListOptions{
@@ -160,7 +160,7 @@ func (w *GitHubWatcher) fetchAndSend(ctx context.Context, repo RepoConfig, msgs 
 
 		msg := eventToMessage(event, repo)
 		select {
-		case msgs <- msg:
+		case msgs <- PitchEvent{Message: msg, Stream: w.config.ResolveStream(repo)}:
 			w.dedup.Mark(repo.FullName(), eventID)
 			newCount++
 		case <-ctx.Done():

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -6,10 +6,17 @@ import (
 	homerun "github.com/stuttgart-things/homerun-library/v3"
 )
 
+// PitchEvent is a message emitted by a watcher together with an optional
+// per-event Redis stream override resolved from the watch config.
+// An empty Stream means "use the pitcher's default".
+type PitchEvent struct {
+	Message homerun.Message
+	Stream  string
+}
+
 // GitWatcher defines the interface for watching Git repositories for events.
 type GitWatcher interface {
 	// Watch starts polling the configured repositories and sends events
-	// as homerun Messages to the returned channel. It blocks until the
-	// context is cancelled.
-	Watch(ctx context.Context) (<-chan homerun.Message, error)
+	// to the returned channel. It blocks until the context is cancelled.
+	Watch(ctx context.Context) (<-chan PitchEvent, error)
 }

--- a/main.go
+++ b/main.go
@@ -89,6 +89,17 @@ func main() {
 
 		ghWatcher := watcher.NewGitHubWatcher(watchCfg, dedup)
 
+		overrides := map[string]string{}
+		for _, repo := range watchCfg.GitHub.Repos {
+			if repo.Stream != "" {
+				overrides[repo.FullName()] = repo.Stream
+			}
+		}
+		slog.Info("stream routing resolved",
+			"default", watchCfg.Stream,
+			"overrides", overrides,
+		)
+
 		// Wire rate limit to health endpoint.
 		rateLimitProvider = func() handlers.RateLimitInfo {
 			s := ghWatcher.RateLimit.Status()

--- a/tests/watch-profile.yaml
+++ b/tests/watch-profile.yaml
@@ -5,6 +5,10 @@
 ## Token supports "env:VAR_NAME" syntax to read from environment variable.
 ##
 
+# Top-level default Redis stream for all published events.
+# Per-repo `stream:` overrides this. Falls back to REDIS_STREAM if unset.
+stream: homerun
+
 github:
   token: env:GITHUB_TOKEN
 
@@ -41,9 +45,12 @@ github:
         - push
         - release
 
-    # External repos (longer interval to save rate limit)
+    # External repos (longer interval to save rate limit).
+    # Releases from upstream favorites go to their own stream so a notification
+    # consumer can subscribe without seeing push/CI traffic.
     - owner: hzeller
       name: rpi-rgb-led-matrix
       interval: 30m
       events:
         - release
+      stream: releases


### PR DESCRIPTION
## Summary
- Add top-level `stream:` and per-repo `stream:` to watch config, plumbed through to the pitcher via homerun-library v3.1.0's `streamOverride` variadic.
- Resolution order: repo override → top-level default → `REDIS_STREAM` env → hardcoded default. Existing env-only setups keep working unchanged.
- Watcher channel now carries `PitchEvent { Message, Stream }` so origin-repo stream preference survives the handoff to the bridge. `Pitcher.Pitch` gains a `streamOverride` arg; `FilePitcher` ignores it, the HTTP handler passes `""`. Startup logs the resolved default + overrides.

Closes #14
Refs stuttgart-things/homerun-library#83

## Test plan
- [x] `go test ./internal/...` green (new `TestResolveStream` + updated `TestBridge_Run` covering the override path)
- [x] `go build .` clean
- [ ] CI: build/lint/image
- [ ] Manual: run with `tests/watch-profile.yaml` (now has `stream: homerun` default + `stream: releases` override on `hzeller/rpi-rgb-led-matrix`) and confirm startup log shows resolved routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)