### PR TITLE
feat(kcl): Option-B HTTPRoute compat — admission defaults + test profile

### DIFF
--- a/kcl/httproute.k
+++ b/kcl/httproute.k
@@ -22,8 +22,15 @@ _httproute = {
             }
     }
     spec: {
+        # group + kind are admission-webhook defaults on parentRefs; rendering
+        # them explicitly avoids drift on every reconcile (Gateway controller
+        # adds them in, ArgoCD compares chart-rendered against live and flags
+        # OutOfSync otherwise). Same shape as stuttgart-things/argocd#114
+        # fix for the standalone httproute chart.
         parentRefs: [
             {
+                group: "gateway.networking.k8s.io"
+                kind: "Gateway"
                 name: _config.httpRouteParentRefName
                 if _config.httpRouteParentRefNamespace:
                     namespace: _config.httpRouteParentRefNamespace
@@ -41,10 +48,15 @@ _httproute = {
                         }
                     }
                 ]
+                # group + kind + weight are admission defaults on backendRefs;
+                # rendering them explicitly prevents the same drift.
                 backendRefs: [
                     {
+                        group: ""
+                        kind: "Service"
                         name: _config.name
                         port: _config.servicePort
+                        weight: 1
                     }
                 ]
             }

--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -7,6 +7,15 @@ config.redisPassword: changeme # pragma: allowlist secret
 config.authToken: changeme # pragma: allowlist secret
 config.githubToken: changeme # pragma: allowlist secret
 config.dedupStatePath: /data/dedup-state.json
+# HTTPRoute lives in the same kustomize apply as the Service so they land
+# atomically — avoids the Cilium gateway controller caching BackendNotFound
+# when the HTTPRoute is created before its Service (stuttgart-things/argocd#116).
+# Consumers without a Gateway API can drop the HTTPRoute via a kustomize delete
+# patch; the homerun2-install chart patches the parentRef + hostname per env.
+config.httpRouteEnabled: true
+config.httpRouteParentRefName: homerun2-dev-gateway
+config.httpRouteParentRefNamespace: default
+config.httpRouteHostname: homerun2-git-pitcher.example.com
 config.watchConfigYaml: |
   github:
     token: env:GITHUB_TOKEN


### PR DESCRIPTION
## Summary

- Render the admission-webhook defaults on the KCL-emitted HTTPRoute so chart-rendered shape matches what Cilium's Gateway controller writes back. Without these, ArgoCD flags `OutOfSync` forever on every reconcile.
- Flip `config.httpRouteEnabled: true` in `tests/kcl-deploy-profile.yaml` so the kustomize OCI built for PR previews ships the HTTPRoute alongside the Service atomically (stuttgart-things/argocd#116).

PR-A of the two repo-side PRs for #25. PR-B (workflow plumbing + `preview` label) lands in parallel.

Ports the shape from stuttgart-things/homerun2-demo-pitcher#25 and stuttgart-things/homerun2-omni-pitcher#127.

## What renders now

```yaml
- apiVersion: gateway.networking.k8s.io/v1
  kind: HTTPRoute
  metadata:
    name: homerun2-git-pitcher
    namespace: homerun2
    labels: { ... }
  spec:
    parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: homerun2-dev-gateway
      namespace: default
    hostnames:
    - homerun2-git-pitcher.example.com
    rules:
    - matches:
      - path:
          type: PathPrefix
          value: /
      backendRefs:
      - group: ''
        kind: Service
        name: homerun2-git-pitcher
        port: 80
        weight: 1
```

Verified locally with `kcl run kcl -D config.httpRouteEnabled=true …` — both the parentRef admission defaults (`group`/`kind`) and the backendRef admission defaults (`group`/`kind`/`weight: 1`) render explicitly.

## Test plan

- [x] `kcl run` against the test profile emits an HTTPRoute with all admission defaults populated
- [ ] `task build-test-binary` is green (verified by CI on this PR)
- [ ] Consumers without a Gateway API can still drop the HTTPRoute via a kustomize delete patch (matches demo-pitcher pattern; no change in this PR)

Refs #25
Refs stuttgart-things/homerun2-omni-pitcher#116

🤖 Generated with [Claude Code](https://claude.com/claude-code)