### PR TITLE
feat(cicd): add 4 PR-preview workflows for the homerun2-pr-preview platform

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -12,7 +12,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-pr:
+    if: github.event_name == 'pull_request'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      registry: ghcr.io
+      tags: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }},pr-${{ github.event.number }}
+    secrets: inherit # pragma: allowlist secret
+
+  build-main:
+    if: github.event_name != 'pull_request'
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
     with:
       runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-pr-artifacts.yaml
+++ b/.github/workflows/cleanup-pr-artifacts.yaml
@@ -1,0 +1,16 @@
+---
+name: Cleanup PR Artifacts
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  cleanup:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-cleanup-pr-artifacts.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      packages: homerun2-git-pitcher,homerun2-git-pitcher-kustomize
+      dry-run: false
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/comment-preview-url.yaml
+++ b/.github/workflows/comment-preview-url.yaml
@@ -1,0 +1,16 @@
+---
+name: Comment Preview URL on PR
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - main
+
+jobs:
+  comment:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-comment-preview-url.yaml@main
+    with:
+      hostname-prefix: git-pr
+      hostname-domain: homerun2-dev.sthings-vsphere.labul.sva.de
+      namespace-prefix: homerun2-git-pitcher-pr
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/push-kustomize-pr.yaml
+++ b/.github/workflows/push-kustomize-pr.yaml
@@ -1,0 +1,21 @@
+---
+name: Push PR Kustomize OCI
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  push-kustomize:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-push-kustomize.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      kcl-source-dir: kcl
+      kcl-profile-file: tests/kcl-deploy-profile.yaml
+      kustomize-oci-repo: ghcr.io/stuttgart-things/homerun2-git-pitcher-kustomize
+      tag: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+    secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary

Wires git-pitcher into the per-PR preview machinery (stuttgart-things/homerun2-omni-pitcher#116 step 3). Mirrors what demo-pitcher, omni-pitcher, core-catcher, and scout already ship.

- **`build-scan-image.yaml`** — split single `build` job into `build-pr` (PR context, tags `pr-<num>-<sha>` + `pr-<num>`) and `build-main` (push context, unchanged).
- **`push-kustomize-pr.yaml`** (new) — renders KCL with the test profile, pushes kustomize OCI to `ghcr.io/stuttgart-things/homerun2-git-pitcher-kustomize:pr-<num>-<sha>`.
- **`comment-preview-url.yaml`** (new) — thin caller; sticky bot comment with preview URL. Hostname prefix `git-pr`, namespace prefix `homerun2-git-pitcher-pr` (matches the upcoming AppSet template).
- **`cleanup-pr-artifacts.yaml`** (new) — on PR close, prunes `pr-<num>-*` package versions for both the image and kustomize OCI.

PR-B of the two repo-side PRs for #25. PR-A (#27) lands the KCL httproute admission defaults + test profile flip in parallel.

## Activation

Previews are gated by the `preview` label on the PR — `gh pr edit <num> --add-label preview` to opt in. Renovate/dependabot bumps stay out by default. The `preview` label is created alongside this PR.

## What still has to land

This is the repo-side of three rollout strands:
- **Chart-side** (argocd): adds `gitPitcher.inlineHttpRoute` opt-in to the install chart.
- **Platform-side** (argocd, blocked on chart): the new `appset-git-pitcher-pr-preview.yaml` + policy rows.

Until those land, these workflows publish artifacts but nothing consumes them.

## Test plan

- [x] CI green on this PR (the 4 jobs run because this PR itself is a PR)
- [ ] Verify a kustomize OCI with tag `pr-<this-PR>-<sha>` lands at `ghcr.io/stuttgart-things/homerun2-git-pitcher-kustomize`
- [ ] Verify the sticky bot comment appears
- [ ] After merging chart + platform PRs and adding `preview` label to a follow-up PR, verify the preview env actually spins up

Refs #25
Refs stuttgart-things/homerun2-omni-pitcher#116

🤖 Generated with [Claude Code](https://claude.com/claude-code)