### PR TITLE
feat(cicd): surface core-catcher dashboard URL in preview comment

### DIFF
--- a/.github/workflows/comment-preview-url.yaml
+++ b/.github/workflows/comment-preview-url.yaml
@@ -13,4 +13,7 @@ jobs:
       hostname-prefix: git-pr
       hostname-domain: homerun2-dev.sthings-vsphere.labul.sva.de
       namespace-prefix: homerun2-git-pitcher-pr
+      # git-pitcher exposes only /health and /metrics; the actual review
+      # surface is the co-tenanted core-catcher dashboard. See #25.
+      additional-urls: 'Dashboard=https://cc-git-pr-${{ github.event.number }}.homerun2-dev.sthings-vsphere.labul.sva.de'
     secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary

git-pitcher itself exposes only `/health` and `/metrics` — the actual review surface for a PR preview is the co-tenanted core-catcher dashboard at `cc-git-pr-<num>.…`. Pass that URL through the new `additional-urls` input on the comment-preview-url workflow template (stuttgart-things/github-workflow-templates#92, merged).

Result on the next preview PR's comment:

```
| | |
|--|--|
| URL | https://git-pr-30.… |
| Health | https://git-pr-30.…/health |
| Dashboard | https://cc-git-pr-30.… |
| Namespace | homerun2-git-pitcher-pr-30 |
| ArgoCD | homerun2-git-pitcher-pr-30 |
```

Surfaced by the #29 / #30 smoke — reviewer had to guess at the cc-git-pr URL.

Refs #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)