### PR TITLE
fix: default to the `messages` Redis stream

### DIFF
--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -23,7 +23,7 @@ schema GitPitcher:
     # Redis
     redisAddr: str = "redis-stack.homerun2.svc.cluster.local"
     redisPort: int | str = "6379"
-    redisStream: str = "homerun"
+    redisStream: str = "messages"
     redisPassword: str = ""
 
     # Auth

--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -2,7 +2,7 @@ config.image: ghcr.io/stuttgart-things/homerun2-git-pitcher:v0.4.0
 config.namespace: homerun2
 config.redisAddr: redis-stack.homerun2.svc.cluster.local
 config.redisPort: "6379"
-config.redisStream: homerun
+config.redisStream: messages
 config.redisPassword: changeme # pragma: allowlist secret
 config.authToken: changeme # pragma: allowlist secret
 config.githubToken: changeme # pragma: allowlist secret

--- a/tests/watch-profile.yaml
+++ b/tests/watch-profile.yaml
@@ -7,7 +7,10 @@
 
 # Top-level default Redis stream for all published events.
 # Per-repo `stream:` overrides this. Falls back to REDIS_STREAM if unset.
-stream: homerun
+# `messages` is the project-wide homerun2 stream — keep this aligned with
+# the rest of the stack so consumers (core-catcher etc.) read what
+# git-pitcher writes without a per-deployment override.
+stream: messages
 
 github:
   token: env:GITHUB_TOKEN


### PR DESCRIPTION
git-pitcher defaulted to a `homerun` Redis stream while the rest of the homerun2 stack (omni-pitcher, core-catcher, …) defaults to `messages`. The mismatch meant a co-tenanted consumer read from an empty stream unless every deployment carried a `redisStream` override — the git-pitcher PR-preview AppSet pinned `coreCatcher.redisStream: homerun` purely to realign the two sides.

Resolves the stream-name fragmentation follow-up from stuttgart-things/homerun2-omni-pitcher#116 by aligning git-pitcher with the project-wide `messages` stream:

- `kcl/schema.k` — `redisStream` default
- `tests/kcl-deploy-profile.yaml` — `config.redisStream`
- `tests/watch-profile.yaml` — top-level `stream`

The Go default (`internal/config/config.go` `REDIS_STREAM` fallback) was already `messages`; this only changes the KCL-rendered deployment. Verified locally — `kcl run` renders `REDIS_STREAM: messages`.

The companion argocd PR drops the now-redundant `coreCatcher.redisStream: homerun` override from `appset-git-pitcher-pr-preview.yaml`. **Merge this PR first** so git-pitcher PR-preview builds write to `messages` before the consumer-side override is removed.

Refs: stuttgart-things/homerun2-omni-pitcher#116

🤖 Generated with [Claude Code](https://claude.com/claude-code)